### PR TITLE
Problem: syn 1.0.60 broke tia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ print = [] # In building time, tia will show the generated result to stderr.
 
 [dependencies]
 lazy_static = "1.4.0"
-syn = {version = "1.0.38", features = ["full", "extra-traits"]}
+syn = {version = ">=1.0.60", features = ["full", "extra-traits"]}

--- a/src/detail/parser/stringify.rs
+++ b/src/detail/parser/stringify.rs
@@ -84,7 +84,7 @@ pub fn decode_type(ty: &syn::Type) -> String
   syn::Type::TraitObject(_ts) => panic!("tia not implemented feature: TraitObject, please write PR or Issue if you want the feature. #TIA-PANIC-3004"),
   syn::Type::Tuple(t) => format!("({})", t.elems.iter().map(|t| decode_type(t)).collect::<Vec<_>>().join(COMMA)),
   syn::Type::Verbatim(v) => v.to_string(),
-  syn::Type::__Nonexhaustive => panic!("tia not implemented feature: __Nonexhaustive, please write PR or Issue if you want the feature. #TIA-PANIC-3003")
+  syn::Type::__TestExhaustive(..) => panic!("tia not implemented feature: __TestExhaustive, please write PR or Issue if you want the feature. #TIA-PANIC-3003")
  }
 }
 


### PR DESCRIPTION
Started getting errors like this:

```
error[E0599]: no variant or associated item named `__Nonexhaustive` found for enum `syn::Type` in the current scope
   |
87 |   syn::Type::__Nonexhaustive => panic!("tia not implemented feature: __Nonexhaustive, please write PR or Issue if you want the feature. #...
   |              ^^^^^^^^^^^^^^^
   |              |
   |              variant or associated item not found in `syn::Type`
   |              help: there is a variant with a similar name: `__TestExhaustive`
```

1.0.59 works fine

Solution: upgrade to 1.0.60